### PR TITLE
Fix to support source relative paths

### DIFF
--- a/internal/ddl/ddl.go
+++ b/internal/ddl/ddl.go
@@ -2,23 +2,9 @@ package ddl
 
 import (
 	"fmt"
-	"path"
 
 	"google.golang.org/protobuf/compiler/protogen"
 )
-
-func removeExt(filename, ext string) string {
-	if path.Ext(filename) == ext {
-		return filename[:len(filename)-len(ext)]
-	}
-	return filename
-}
-
-func generatingFilePath(sourceFilePath string) string {
-	generatingFilePath := removeExt(sourceFilePath, ".proto")
-	generatingFilePath += "_ddl.pb.sql"
-	return generatingFilePath
-}
 
 func GenerateDDLFiles(version string, gen *protogen.Plugin) error {
 	extensionTypes, err := loadAllExtensionTypes(*gen)
@@ -31,7 +17,8 @@ func GenerateDDLFiles(version string, gen *protogen.Plugin) error {
 			continue
 		}
 
-		generatedSQLFile := gen.NewGeneratedFile(generatingFilePath(sourceFile.Desc.Path()), protogen.GoImportPath(sourceFile.GoPackageName))
+		sqlFileSuffix := "_ddl.pb.sql"
+		generatedSQLFile := gen.NewGeneratedFile(sourceFile.GeneratedFilenamePrefix+sqlFileSuffix, sourceFile.GoImportPath)
 
 		addFileHead(version, generatedSQLFile, gen, sourceFile)
 


### PR DESCRIPTION
now we can use like `protoc -I=. --go_out ../gen/go/ --go_opt paths=source_relative --go-ddl_out ../gen/go/ --go-ddl_opt paths=source_relative ./**/*.proto`.